### PR TITLE
Add fastapi and uvicorn dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ anyio==4.9.0
     #   -c requirements/common-constraints.txt
     #   httpx
     #   openai
+    #   starlette
     #   watchfiles
 attrs==25.3.0
     # via
@@ -60,6 +61,7 @@ click==8.1.8
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
+    #   uvicorn
 configargparse==1.7.1
     # via
     #   -c requirements/common-constraints.txt
@@ -77,6 +79,8 @@ distro==1.9.0
     #   -c requirements/common-constraints.txt
     #   openai
     #   posthog
+fastapi==0.115.12
+    # via -r requirements/requirements.in
 filelock==3.18.0
     # via
     #   -c requirements/common-constraints.txt
@@ -154,6 +158,7 @@ h11==0.16.0
     # via
     #   -c requirements/common-constraints.txt
     #   httpcore
+    #   uvicorn
 hf-xet==1.1.0
     # via
     #   -c requirements/common-constraints.txt
@@ -336,6 +341,7 @@ pycparser==2.22
 pydantic==2.11.4
     # via
     #   -c requirements/common-constraints.txt
+    #   fastapi
     #   google-generativeai
     #   litellm
     #   openai
@@ -449,6 +455,8 @@ soupsieve==2.7
     # via
     #   -c requirements/common-constraints.txt
     #   beautifulsoup4
+starlette==0.46.2
+    # via fastapi
 tiktoken==0.9.0
     # via
     #   -c requirements/common-constraints.txt
@@ -463,6 +471,7 @@ tqdm==4.67.1
     #   google-generativeai
     #   huggingface-hub
     #   openai
+tree-sitter==0.24.0
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack
@@ -487,6 +496,7 @@ typing-extensions==4.13.2
     #   -c requirements/common-constraints.txt
     #   anyio
     #   beautifulsoup4
+    #   fastapi
     #   google-generativeai
     #   huggingface-hub
     #   openai
@@ -507,6 +517,8 @@ urllib3==2.4.0
     #   -c requirements/common-constraints.txt
     #   mixpanel
     #   requests
+uvicorn==0.34.3
+    # via -r requirements/requirements.in
 watchfiles==1.0.5
     # via
     #   -c requirements/common-constraints.txt
@@ -523,6 +535,5 @@ zipp==3.21.0
     # via
     #   -c requirements/common-constraints.txt
     #   importlib-metadata
-    
 tree-sitter==0.23.2; python_version < "3.10"
 tree-sitter==0.24.0; python_version >= "3.10"

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -30,6 +30,8 @@ pillow
 shtab
 oslex
 google-generativeai
+fastapi
+uvicorn
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps


### PR DESCRIPTION
Adding these dependencies will avoid this error when running the uvicorn server.
`ModuleNotFoundError: No module named 'oslex'`